### PR TITLE
Youbora player behaviour for android

### DIFF
--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -72,6 +72,7 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_HIDE_SHUTTER_VIEW = "hideShutterView";
     private static final String PROP_CONTROLS = "controls";
     private static final String PROP_ANALYTICS_META = "analyticsMeta";
+    private static final String PROP_ORIGIN = "origin";
 
     private ReactExoplayerConfig config;
 
@@ -346,6 +347,13 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     public void setAnalyticsMeta(final ReactExoplayerView videoView, @Nullable ReadableMap analyticsMeta) {
         if (analyticsMeta != null) {
             videoView.setAnalyticsMeta(analyticsMeta);
+        }
+    }
+
+    @ReactProp(name = PROP_ORIGIN)
+    public void setOrigin(final ReactExoplayerView videoView, @Nullable String origin) {
+        if (origin != null) {
+            videoView.setOrigin(origin);
         }
     }
 


### PR DESCRIPTION
We will be using origin prop to determine if the player origin was from tv guide or not. If it was from tv guide then we use the youbora initialisation logic from the analytics setter. If not then its just initialisation from the run. It is weird that the player is already mounted when u open the player via tv guide but it is not mounted if you open the player via LiveTV page or VoD details page hence this logic separation.