### PR TITLE
revert exclusive audio focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,5 @@
 ## Changelog
 
-### Version 5.x 2022/10/04.
-
-- Fix Android TV AudioFocus specific case
-  Android-TV has a specific use-case not related to the “Play-Pause” button (intention) 
-  forwarded to all apps even the ones in background.
-  So if App is active we must capture back the AudioFocus to any “concurrent” sound App.
-
-  Test with music App (e.g. TuneIn) VS video player,
-  on play-pause the music App sound should not come to foreground
-
 ### Version 
 
 - Fix Android AudioFocus bug that could cause player to not respond to play/pause in some instances [#2311](https://github.com/react-native-video/react-native-video/pull/2311)

--- a/Video.js
+++ b/Video.js
@@ -473,8 +473,6 @@ Video.propTypes = {
   disableFocus: PropTypes.bool,
   controls: PropTypes.bool,
   audioOnly: PropTypes.bool,
-  androidTV: PropTypes.bool,
-  androidTVActiveApp: PropTypes.bool,
   currentTime: PropTypes.number,
   fullscreenAutorotate: PropTypes.bool,
   fullscreenOrientation: PropTypes.oneOf(['all', 'landscape', 'portrait']),

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerView.java
@@ -174,8 +174,6 @@ class ReactExoplayerView extends FrameLayout implements
     private String assetId = null;
     private boolean controls;
     private ReadableMap analyticsMeta;
-    private boolean isATVActiveApp = false;
-    private boolean isAndroidTV = false;
     // \ End props
 
     // React
@@ -869,16 +867,10 @@ class ReactExoplayerView extends FrameLayout implements
     public void onAudioFocusChange(int focusChange) {
         switch (focusChange) {
             case AudioManager.AUDIOFOCUS_LOSS:
-                if (isAndroidTV && isATVActiveApp) {
-                    audioManager.requestAudioFocus(this,
-                        AudioManager.STREAM_MUSIC,
-                        AudioManager.AUDIOFOCUS_GAIN);
-                } else {
-                    this.hasAudioFocus = false;
-                    eventEmitter.audioFocusChanged(false);
-                    pausePlayback();
-                    audioManager.abandonAudioFocus(this);
-                }
+                this.hasAudioFocus = false;
+                eventEmitter.audioFocusChanged(false);
+                pausePlayback();
+                audioManager.abandonAudioFocus(this);
                 break;
             case AudioManager.AUDIOFOCUS_LOSS_TRANSIENT:
                 eventEmitter.audioFocusChanged(false);
@@ -1548,14 +1540,6 @@ class ReactExoplayerView extends FrameLayout implements
             youboraPlugin.getAdapter().fireStop();
             initialiseYoubora();
         }
-    }
-
-    public void setAndroidTV(boolean isAndroidTV) {
-        this.isAndroidTV = isAndroidTV;
-    }
-
-    public void setATVActiveApp(boolean isATVActiveApp) {
-        this.isATVActiveApp = isATVActiveApp;
     }
 
     public void setAssetId(String assetId){

--- a/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
+++ b/android-exoplayer/src/main/java/com/brentvatne/exoplayer/ReactExoplayerViewManager.java
@@ -72,8 +72,6 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     private static final String PROP_HIDE_SHUTTER_VIEW = "hideShutterView";
     private static final String PROP_CONTROLS = "controls";
     private static final String PROP_ANALYTICS_META = "analyticsMeta";
-    private static final String PROP_ANDROID_TV = "androidTV";
-    private static final String PROP_ATV_ACTIVE_APP = "androidTVActiveApp";
 
     private ReactExoplayerConfig config;
 
@@ -323,16 +321,6 @@ public class ReactExoplayerViewManager extends ViewGroupManager<ReactExoplayerVi
     @ReactProp(name = PROP_CONTROLS, defaultBoolean = false)
     public void setControls(final ReactExoplayerView videoView, final boolean controls) {
         videoView.setControls(controls);
-    }
-
-    @ReactProp(name = PROP_ANDROID_TV, defaultBoolean = false)
-    public void setAndroidTV(final ReactExoplayerView videoView, final boolean androidTV) {
-        videoView.setAndroidTV(androidTV);
-    }
-
-    @ReactProp(name = PROP_ATV_ACTIVE_APP, defaultBoolean = false)
-    public void setATVActiveApp(final ReactExoplayerView videoView, final boolean activeApp) {
-        videoView.setATVActiveApp(activeApp);
     }
 
     @ReactProp(name = PROP_BUFFER_CONFIG)


### PR DESCRIPTION
Reverting the exclusive audio focus,
leads to fight for focus in other apps 
we will now rely on not forwarding trick-play keys (Rewind, Play/Pause, Fast-Forward) to not awake other apps and thus keeping focus on our app.